### PR TITLE
Extend `--ymd` and `--hms` options to accept readable format.

### DIFF
--- a/src/argv.rs
+++ b/src/argv.rs
@@ -21,18 +21,3 @@ pub trait ParseArgv<T> {
 pub trait ValidateArgv {
     fn validate_argv(s: String) -> Result<(), String>;
 }
-
-fn validate_number(field_name: &str, min: i32, max: i32, text: &str) -> Result<(), String> {
-    let number = text
-        .parse::<i32>()
-        .map_err(|_| format!("{} is not a number.", text))?;
-
-    if number >= min && number <= max {
-        Ok(())
-    } else {
-        Err(format!(
-            "{} must be between {} and {} . given {}: {}",
-            field_name, min, max, field_name, text
-        ))
-    }
-}

--- a/src/argv/hms.rs
+++ b/src/argv/hms.rs
@@ -1,8 +1,11 @@
 use chrono::NaiveTime;
-use regex::Regex;
+use failure::{Fail, ResultExt};
+use regex::{Match, Regex};
 
-use crate::argv::{validate_number, ParseArgv, ValidateArgv};
-use crate::error::UtError;
+use crate::argv::{ParseArgv, ValidateArgv};
+use crate::error::{UtError, UtErrorKind};
+use std::fmt::Debug;
+use std::str::FromStr;
 
 pub struct HmsArgv {}
 
@@ -14,30 +17,133 @@ impl Default for HmsArgv {
 
 impl ParseArgv<NaiveTime> for HmsArgv {
     fn parse_argv(&self, hms: &str) -> Result<NaiveTime, UtError> {
-        let h = *&hms[0..2].parse::<u32>().expect("not a number");
-        let m = *&hms[2..4].parse::<u32>().expect("not a number");
-        let s = *&hms[4..6].parse::<u32>().expect("not a number");
-
-        Ok(NaiveTime::from_hms(h, m, s))
+        let hms = Hms::from_str(hms).context(UtErrorKind::WrongTime)?;
+        Ok(NaiveTime::from_hms(hms.h, hms.m, hms.s))
     }
 }
 
 impl ValidateArgv for HmsArgv {
     fn validate_argv(hms: String) -> Result<(), String> {
-        let re = Regex::new(r"(\d{2})(\d{2})(\d{2})").expect("wrong regex pattern");
-        let caps = re
-            .captures(&hms)
-            .ok_or(format!("format must be \"HHmmss\". given format: {}", hms))?;
+        Hms::from_str(&hms)
+            .context(UtErrorKind::WrongTime)
+            .map(|_| ())
+            .map_err(|e| {
+                let e = UtError::from(e);
+                format!(
+                    "{}{}",
+                    e,
+                    e.cause()
+                        .map_or("".to_string(), |c| format!(" cause: {:?}", c))
+                )
+            })
+    }
+}
 
-        let h = caps.get(1).unwrap().as_str();
-        validate_number("hour", 0, 23, h)?;
+#[derive(Fail, Debug, PartialEq)]
+pub enum HmsError {
+    #[fail(
+        display = "Wrong hms text: '{}'. text must be in `Hmmss` or `HH:mm:ss` format.",
+        _0
+    )]
+    WrongFormat(String),
 
-        let m = caps.get(2).unwrap().as_str();
-        validate_number("minute", 0, 59, m)?;
+    #[fail(display = "Wrong hour: '{}'. hour must be between 0 and 23.", _0)]
+    WrongHour(String),
 
-        let s = caps.get(3).unwrap().as_str();
-        validate_number("second", 0, 59, s)?;
+    #[fail(display = "Wrong minute: '{}'. minute must be between 0 and 59.", _0)]
+    WrongMinute(String),
 
+    #[fail(display = "Wrong second: '{}'. second must be between 0 and 59.", _0)]
+    WrongSecond(String),
+}
+
+struct Hms {
+    h: u32,
+    m: u32,
+    s: u32,
+}
+
+impl FromStr for Hms {
+    type Err = HmsError;
+
+    fn from_str(text: &str) -> Result<Self, Self::Err> {
+        let re = Regex::new(r"^(?:(\d{2})(\d{2})(\d{2})|(\d{1,2})[:](\d{1,2})[:](\d{1,2}))$")
+            .expect("wrong regex pattern");
+
+        re.captures(text)
+            .map(|capture| {
+                let h = extract_number(capture.get(1).or(capture.get(4)));
+                let m = extract_number(capture.get(2).or(capture.get(5)));
+                let s = extract_number(capture.get(3).or(capture.get(6)));
+
+                validate_number(h, 0, 23, || HmsError::WrongHour(text.to_string()))
+                    .and_then(|_| {
+                        validate_number(m, 0, 59, || HmsError::WrongMinute(text.to_string()))
+                    })
+                    .and_then(|_| {
+                        validate_number(s, 0, 59, || HmsError::WrongSecond(text.to_string()))
+                    })
+                    .map(|_| Hms { h, m, s })
+            })
+            .unwrap_or(Err(HmsError::WrongFormat(text.to_string())))
+    }
+}
+
+fn extract_number<E: Debug, T: FromStr<Err = E>>(maybe_match: Option<Match>) -> T {
+    maybe_match
+        .map(|m| m.as_str().parse().expect("must be a number text."))
+        .unwrap()
+}
+
+fn validate_number<T: PartialOrd, E, F: Fn() -> E>(n: T, min: T, max: T, f: F) -> Result<(), E> {
+    if n >= min && n <= max {
         Ok(())
+    } else {
+        Err(f())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::argv::HmsArgv;
+    use crate::argv::{ParseArgv, ValidateArgv};
+    use chrono::NaiveTime;
+
+    #[test]
+    fn parse() {
+        let argv = HmsArgv::default();
+
+        assert_eq!(
+            argv.parse_argv("112233").ok(),
+            Some(NaiveTime::from_hms(11, 22, 33))
+        );
+
+        assert_eq!(
+            argv.parse_argv("11:22:33").ok(),
+            Some(NaiveTime::from_hms(11, 22, 33))
+        );
+
+        assert_eq!(
+            argv.parse_argv("1:2:3").ok(),
+            Some(NaiveTime::from_hms(1, 2, 3))
+        );
+    }
+
+    #[test]
+    fn validate() {
+        assert!(HmsArgv::validate_argv("112233".to_string()).is_ok());
+        assert!(HmsArgv::validate_argv("11:22:33".to_string()).is_ok());
+        assert!(HmsArgv::validate_argv("1:2:3".to_string()).is_ok());
+        assert!(HmsArgv::validate_argv("00:00:00".to_string()).is_ok());
+        assert!(HmsArgv::validate_argv("23:59:59".to_string()).is_ok());
+
+        assert!(HmsArgv::validate_argv("".to_string()).is_err());
+        assert!(HmsArgv::validate_argv("1122334".to_string()).is_err());
+        assert!(HmsArgv::validate_argv("11".to_string()).is_err());
+        assert!(HmsArgv::validate_argv("1122".to_string()).is_err());
+        assert!(HmsArgv::validate_argv("11:".to_string()).is_err());
+        assert!(HmsArgv::validate_argv("11:22".to_string()).is_err());
+        assert!(HmsArgv::validate_argv("11:22:".to_string()).is_err());
+        assert!(HmsArgv::validate_argv("::".to_string()).is_err());
     }
 }

--- a/src/argv/ymd.rs
+++ b/src/argv/ymd.rs
@@ -1,12 +1,12 @@
+use std::fmt::Debug;
+use std::str::FromStr;
+
 use chrono::{Date, LocalResult, TimeZone};
-use regex::Regex;
+use failure::{Fail, ResultExt};
+use regex::{Match, Regex};
 
-use crate::argv::{validate_number, ParseArgv, ValidateArgv};
+use crate::argv::{ParseArgv, ValidateArgv};
 use crate::error::{UtError, UtErrorKind};
-
-fn extract_int(s: &str, start: usize, stop: usize) -> i32 {
-    *&s[start..stop].parse().expect("not a number")
-}
 
 pub struct YmdArgv<Tz: TimeZone> {
     tz: Tz,
@@ -19,37 +19,169 @@ impl<Tz: TimeZone> From<Tz> for YmdArgv<Tz> {
 }
 
 impl<Tz: TimeZone> ParseArgv<Date<Tz>> for YmdArgv<Tz> {
-    fn parse_argv(&self, ymd: &str) -> Result<Date<Tz>, UtError> {
-        let year_len = ymd.len() - 4;
-        let y = extract_int(ymd, 0, year_len);
-        let m = extract_int(ymd, year_len, year_len + 2);
-        let d = extract_int(ymd, year_len + 2, year_len + 4);
-
-        match self.tz.ymd_opt(y, m as u32, d as u32) {
+    fn parse_argv(&self, s: &str) -> Result<Date<Tz>, UtError> {
+        let ymd = Ymd::from_str(s).context(UtErrorKind::WrongDate)?;
+        match self.tz.ymd_opt(ymd.y, ymd.m, ymd.d) {
             LocalResult::Single(date) => Ok(date),
-            LocalResult::None => Err(UtError::from(UtErrorKind::WrongDate)),
-            LocalResult::Ambiguous(_, _) => Err(UtError::from(UtErrorKind::AmbiguousDate)),
+            LocalResult::None => {
+                Err(YmdError::WrongDate(s.to_string())).context(UtErrorKind::WrongDate)?
+            }
+            LocalResult::Ambiguous(_, _) => {
+                Err(YmdError::WrongDate(s.to_string())).context(UtErrorKind::AmbiguousDate)?
+            }
         }
     }
 }
 
 impl<Tz: TimeZone> ValidateArgv for YmdArgv<Tz> {
-    fn validate_argv(ymd: String) -> Result<(), String> {
-        let re = Regex::new(r"(\d{4})(\d{2})(\d{2})").expect("wrong regex pattern");
-        let caps = re.captures(&ymd).ok_or(format!(
-            "format must be \"yyyyMMdd\". given format: {}",
-            ymd
-        ))?;
-
-        let y = caps.get(1).unwrap().as_str();
-        validate_number("year", 1900, 2999, y)?;
-
-        let m = caps.get(2).unwrap().as_str();
-        validate_number("month", 1, 12, m)?;
-
-        let d = caps.get(3).unwrap().as_str();
-        validate_number("day", 1, 31, d)?;
-
-        Ok(())
+    fn validate_argv(s: String) -> Result<(), String> {
+        Ymd::from_str(&s)
+            .context(UtErrorKind::WrongDate)
+            .map(|_| ())
+            .map_err(|e| {
+                let e = UtError::from(e);
+                format!(
+                    "{}{}",
+                    e,
+                    e.cause()
+                        .map_or("".to_string(), |c| format!(" cause: {:?}", c))
+                )
+            })
     }
+}
+
+struct Ymd {
+    y: i32,
+    m: u32,
+    d: u32,
+}
+
+#[derive(Fail, Debug, PartialEq)]
+pub enum YmdError {
+    #[fail(
+        display = "Wrong ymd text: '{}'. text must be in `yyyyMMdd` or `yyyy-MM-dd` format.",
+        _0
+    )]
+    WrongFormat(String),
+
+    #[fail(
+        display = "Wrong year: '{}'. year must be between {} and {}.",
+        _0, _1, _2
+    )]
+    WrongYear(String, i32, i32),
+
+    #[fail(display = "Wrong month: '{}'. month must be between 1 and 12.", _0)]
+    WrongMonth(String),
+
+    #[fail(display = "Wrong day: '{}'. day must be between 1 and 31.", _0)]
+    WrongDay(String),
+
+    #[fail(display = "Wrong date: '{}'.", _0)]
+    WrongDate(String),
+}
+
+impl FromStr for Ymd {
+    type Err = YmdError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let re = Regex::new(r"^(?:(\d{4})(\d{2})(\d{2})|(\d{4})[-/](\d{1,2})[-/](\d{1,2}))$")
+            .expect("wrong regex pattern");
+
+        re.captures(s)
+            .map(|capture| {
+                let y = extract_number(capture.get(1).or(capture.get(4)));
+                let m = extract_number(capture.get(2).or(capture.get(5)));
+                let d = extract_number(capture.get(3).or(capture.get(6)));
+
+                validate_number(y, 1900, 2999, || {
+                    YmdError::WrongYear(s.to_string(), 1900, 2999)
+                })
+                .and_then(|_| validate_number(m, 1, 12, || YmdError::WrongMonth(s.to_string())))
+                .and_then(|_| validate_number(d, 1, 31, || YmdError::WrongDay(s.to_string())))
+                .map(|_| Ymd { y, m, d })
+            })
+            .unwrap_or(Err(YmdError::WrongFormat(s.to_string())))
+    }
+}
+
+fn extract_number<E: Debug, T: FromStr<Err = E>>(maybe_match: Option<Match>) -> T {
+    maybe_match
+        .map(|m| m.as_str().parse().expect("must be a number text."))
+        .unwrap()
+}
+
+fn validate_number<T: PartialOrd, E, F: Fn() -> E>(n: T, min: T, max: T, f: F) -> Result<(), E> {
+    if n >= min && n <= max {
+        Ok(())
+    } else {
+        Err(f())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{Date, Utc};
+
+    use crate::argv::{ParseArgv, ValidateArgv, YmdArgv};
+    use chrono::offset::TimeZone;
+
+    fn timestamp_of<Tz: TimeZone>(d: Date<Tz>) -> i64 {
+        d.and_hms(0, 0, 0).timestamp()
+    }
+
+    #[test]
+    fn parse() {
+        let argv = YmdArgv::from(Utc);
+        assert_eq!(
+            argv.parse_argv("20190621").map(timestamp_of).unwrap_or(0),
+            timestamp_of(Utc.ymd(2019, 6, 21))
+        );
+        assert_eq!(
+            argv.parse_argv("2019-06-21").map(timestamp_of).unwrap_or(0),
+            timestamp_of(Utc.ymd(2019, 6, 21))
+        );
+        assert_eq!(
+            argv.parse_argv("2019/06/21").map(timestamp_of).unwrap_or(0),
+            timestamp_of(Utc.ymd(2019, 6, 21))
+        );
+        assert_eq!(
+            argv.parse_argv("2019/6/1").map(timestamp_of).unwrap_or(0),
+            timestamp_of(Utc.ymd(2019, 6, 1))
+        );
+
+        assert!(argv.parse_argv("2020/2/29").is_ok());
+        assert!(argv.parse_argv("2019/2/29").is_err());
+    }
+
+    #[test]
+    fn validate() {
+        assert!(YmdArgv::<Utc>::validate_argv("20190621".to_string()).is_ok());
+        assert!(YmdArgv::<Utc>::validate_argv("2019-06-21".to_string()).is_ok());
+        assert!(YmdArgv::<Utc>::validate_argv("2019/06/21".to_string()).is_ok());
+        assert!(YmdArgv::<Utc>::validate_argv("2019/6/1".to_string()).is_ok());
+
+        assert!(YmdArgv::<Utc>::validate_argv("2019".to_string()).is_err());
+        assert!(YmdArgv::<Utc>::validate_argv("201906".to_string()).is_err());
+        assert!(YmdArgv::<Utc>::validate_argv("2019061".to_string()).is_err());
+        assert!(YmdArgv::<Utc>::validate_argv("201906011".to_string()).is_err());
+        assert!(YmdArgv::<Utc>::validate_argv("18990101".to_string()).is_err());
+        assert!(YmdArgv::<Utc>::validate_argv("30000101".to_string()).is_err());
+        assert!(YmdArgv::<Utc>::validate_argv("29990001".to_string()).is_err());
+        assert!(YmdArgv::<Utc>::validate_argv("29991301".to_string()).is_err());
+        assert!(YmdArgv::<Utc>::validate_argv("29990132".to_string()).is_err());
+
+        assert!(YmdArgv::<Utc>::validate_argv("2019".to_string()).is_err());
+        assert!(YmdArgv::<Utc>::validate_argv("2019-".to_string()).is_err());
+        assert!(YmdArgv::<Utc>::validate_argv("2019-06".to_string()).is_err());
+        assert!(YmdArgv::<Utc>::validate_argv("2019-06-".to_string()).is_err());
+        assert!(YmdArgv::<Utc>::validate_argv("2019-06-".to_string()).is_err());
+        assert!(YmdArgv::<Utc>::validate_argv("-06-01".to_string()).is_err());
+        assert!(YmdArgv::<Utc>::validate_argv("99999-06-01".to_string()).is_err());
+        assert!(YmdArgv::<Utc>::validate_argv("2019--01".to_string()).is_err());
+        assert!(YmdArgv::<Utc>::validate_argv("2019-123-01".to_string()).is_err());
+        assert!(YmdArgv::<Utc>::validate_argv("2019-06-".to_string()).is_err());
+        assert!(YmdArgv::<Utc>::validate_argv("2019-06-123".to_string()).is_err());
+        assert!(YmdArgv::<Utc>::validate_argv("--".to_string()).is_err());
+    }
+
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,6 +18,9 @@ pub enum UtErrorKind {
     #[fail(display = "Wrong date.")]
     WrongDate,
 
+    #[fail(display = "Wrong time.")]
+    WrongTime,
+
     #[fail(display = "Date is ambiguous.")]
     AmbiguousDate,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,11 +33,11 @@ impl Fail for UtError {
     }
 
     fn cause(&self) -> Option<&Fail> {
-        unimplemented!()
+        self.inner.cause()
     }
 
     fn backtrace(&self) -> Option<&Backtrace> {
-        unimplemented!()
+        self.inner.backtrace()
     }
 }
 


### PR DESCRIPTION
Extend ymd/hms options to accept readable formats like..
- ymd: `yyyy-MM-dd` or `yyyy/MM/dd`
- hms: `HH:mm:ss`