### PR TITLE
Move timedelta into ut-cli crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,14 +290,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "timedelta"
-version = "0.1.0"
-dependencies = [
- "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "ucd-util"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,7 +320,7 @@ dependencies = [
  "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "timedelta 0.1.0",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,17 +15,12 @@ license = "MIT"
 name = "ut"
 path = "src/main.rs"
 
-[workspace]
-members = [
-    "timedelta",
-]
-
 [dependencies]
 chrono = "^0.4"
 clap = "^2.33"
 failure = "^0.1"
+lazy_static = "^1.3"
 regex = "^1"
 strum = "^0.15"
 strum_macros = "^0.15"
-timedelta = {version = "^0.1.0", "path" = "timedelta"}
-lazy_static = "^1.3"
+time = "^0.1"

--- a/src/cmd/generate.rs
+++ b/src/cmd/generate.rs
@@ -1,8 +1,6 @@
 use chrono::{Date, DateTime, NaiveTime, TimeZone, Utc};
 use clap::{App, Arg, ArgMatches, SubCommand, Values};
 
-use timedelta::{ApplyDateTime, TimeDeltaBuilder};
-
 use crate::argv::{
     DeltaArgv, HmsArgv, ParseArgv, PrecisionArgv, PresetArgv, TimeUnitArgv, ValidateArgv, YmdArgv,
 };
@@ -10,6 +8,7 @@ use crate::delta::DeltaItem;
 use crate::error::{UtError, UtErrorKind};
 use crate::precision::Precision;
 use crate::preset::{DateFixture, Preset};
+use crate::timedelta::{ApplyDateTime, TimeDeltaBuilder};
 use crate::unit::TimeUnit;
 
 pub fn command(name: &str) -> App<'static, 'static> {

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -2,9 +2,9 @@ use std::str::FromStr;
 
 use failure::Fail;
 use regex::Regex;
-use timedelta::TimeDeltaBuilder;
 
 use crate::find::FindError;
+use crate::timedelta::TimeDeltaBuilder;
 use crate::unit::TimeUnit;
 
 #[derive(Fail, Debug, PartialEq)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod error;
 mod find;
 mod precision;
 mod preset;
+mod timedelta;
 mod unit;
 
 use std::fmt::Display;
@@ -14,9 +15,9 @@ use clap::{
     crate_authors, crate_description, crate_name, crate_version, App, AppSettings, Arg, ArgMatches,
 };
 
-use crate::preset::FixedOffsetDateFixture;
 use crate::argv::{OffsetArgv, ParseArgv, ValidateArgv};
 use crate::error::UtError;
+use crate::preset::FixedOffsetDateFixture;
 use crate::preset::{DateFixture, LocalDateFixture, UtcDateFixture};
 
 fn app() -> App<'static, 'static> {

--- a/src/preset.rs
+++ b/src/preset.rs
@@ -3,9 +3,8 @@ use lazy_static::lazy_static;
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter, EnumString};
 
-use timedelta::{ApplyDateTime, TimeDeltaBuilder};
-
 use crate::find::{enum_names, find_enum_item, FindError};
+use crate::timedelta::{ApplyDateTime, TimeDeltaBuilder};
 
 #[derive(Debug, Copy, Clone, PartialEq, EnumIter, EnumString, Display)]
 pub enum Preset {

--- a/src/timedelta.rs
+++ b/src/timedelta.rs
@@ -11,6 +11,7 @@ pub struct TimeDelta {
 }
 
 impl TimeDelta {
+    #[allow(dead_code)]
     pub fn new(
         years: i32,
         months: i32,
@@ -207,6 +208,7 @@ impl TimeDeltaBuilder {
         self.seconds(s)
     }
 
+    #[allow(dead_code)]
     pub fn milliseconds(self, value: i32) -> Self {
         let s = value / 1000;
         let us = (value % 1000) * 1000;
@@ -248,6 +250,7 @@ struct DeltaValues {
     microseconds: i32,
 }
 
+#[allow(dead_code)]
 fn sign_of(x: i32) -> i32 {
     if x > 0 {
         1
@@ -256,16 +259,17 @@ fn sign_of(x: i32) -> i32 {
     }
 }
 
+#[allow(dead_code)]
 fn div_mod(x: i32, y: i32) -> (i32, i32) {
     (x / y, x % y)
 }
 
 #[cfg(test)]
 mod time_delta_tests {
-    use crate::delta::{ApplyDateTime, TimeDelta};
-    use crate::TimeDeltaBuilder;
     use chrono::offset::TimeZone;
     use chrono::Utc;
+
+    use super::{ApplyDateTime, TimeDelta, TimeDeltaBuilder};
 
     #[test]
     fn time_delta_new_basics() {

--- a/timedelta/Cargo.toml
+++ b/timedelta/Cargo.toml
@@ -1,9 +1,0 @@
-[package]
-name = "timedelta"
-version = "0.1.0"
-authors = ["yoshihitoh <yoshihito.arih@gmail.com>"]
-edition = "2018"
-
-[dependencies]
-chrono = "^0.4"
-time = "^0.1"

--- a/timedelta/src/lib.rs
+++ b/timedelta/src/lib.rs
@@ -1,5 +1,0 @@
-mod delta;
-
-pub use self::delta::ApplyDateTime;
-pub use self::delta::TimeDelta;
-pub use self::delta::TimeDeltaBuilder;


### PR DESCRIPTION
- stop separating the crate `timedelta`
- move into `ut-cli` crate (to prepare to publish the package)