### PR TITLE
Rename `DateFixture` to `DateTimeProvider`.

### DIFF
--- a/src/cmd/parse.rs
+++ b/src/cmd/parse.rs
@@ -5,7 +5,7 @@ use regex::Regex;
 
 use crate::error::{UtError, UtErrorKind};
 use crate::precision::Precision;
-use crate::preset::DateFixture;
+use crate::provider::DateTimeProvider;
 use std::fmt::Display;
 
 pub fn command(name: &str) -> App<'static, 'static> {
@@ -30,11 +30,11 @@ pub fn command(name: &str) -> App<'static, 'static> {
         )
 }
 
-pub fn run<O, Tz, F>(m: &ArgMatches, fixture: F) -> Result<(), UtError>
+pub fn run<O, Tz, P>(m: &ArgMatches, provider: P) -> Result<(), UtError>
 where
     O: Offset + Display + Sized,
     Tz: TimeZone<Offset = O>,
-    F: DateFixture<Tz>,
+    P: DateTimeProvider<Tz>,
 {
     let timestamp = m
         .value_of("TIMESTAMP")
@@ -46,7 +46,7 @@ where
         .map_err(|e| e.context(UtErrorKind::PrecisionError))
         .map_err(UtError::from)?;
 
-    let dt = precision.parse_timestamp(fixture.timezone(), timestamp);
+    let dt = precision.parse_timestamp(provider.timezone(), timestamp);
     println!("{}", dt.format(precision.preferred_format()).to_string());
     Ok(())
 }

--- a/src/preset.rs
+++ b/src/preset.rs
@@ -1,10 +1,10 @@
-use chrono::{Date, DateTime, FixedOffset, Local, TimeZone, Utc};
+use chrono::{Date, TimeZone};
 use lazy_static::lazy_static;
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter, EnumString};
 
 use crate::find::{enum_names, find_enum_item, FindError};
-use crate::timedelta::{ApplyDateTime, TimeDeltaBuilder};
+use crate::provider::DateTimeProvider;
 
 #[derive(Debug, Copy, Clone, PartialEq, EnumIter, EnumString, Display)]
 pub enum Preset {
@@ -33,107 +33,15 @@ impl Preset {
         Preset::iter().map(|p| p.to_string()).collect()
     }
 
-    pub fn as_date<F, Tz>(&self, fixture: &F) -> Date<Tz>
+    pub fn as_date<P, Tz>(&self, provider: &P) -> Date<Tz>
     where
-        F: DateFixture<Tz>,
+        P: DateTimeProvider<Tz>,
         Tz: TimeZone,
     {
         match *self {
-            Preset::Today => fixture.today(),
-            Preset::Tomorrow => fixture.tomorrow(),
-            Preset::Yesterday => fixture.yesterday(),
+            Preset::Today => provider.today(),
+            Preset::Tomorrow => provider.tomorrow(),
+            Preset::Yesterday => provider.yesterday(),
         }
-    }
-}
-
-fn add_days<Tz: TimeZone>(date: Date<Tz>, days: i32) -> Date<Tz> {
-    let delta = TimeDeltaBuilder::default().days(days).build();
-    delta
-        .apply_datetime(date.and_hms(0, 0, 0))
-        .expect(&format!("can't add days. date={:?}, days={}", date, days))
-        .date()
-}
-
-pub trait DateFixture<Tz: TimeZone> {
-    fn timezone(&self) -> Tz;
-
-    fn now(&self) -> DateTime<Tz>;
-
-    fn today(&self) -> Date<Tz>;
-
-    fn tomorrow(&self) -> Date<Tz> {
-        add_days(self.today(), 1)
-    }
-
-    fn yesterday(&self) -> Date<Tz> {
-        add_days(self.today(), -1)
-    }
-}
-
-pub struct UtcDateFixture {}
-
-impl Default for UtcDateFixture {
-    fn default() -> Self {
-        UtcDateFixture {}
-    }
-}
-
-impl DateFixture<Utc> for UtcDateFixture {
-    fn timezone(&self) -> Utc {
-        Utc
-    }
-
-    fn now(&self) -> DateTime<Utc> {
-        Utc::now()
-    }
-
-    fn today(&self) -> Date<Utc> {
-        Utc::today()
-    }
-}
-
-pub struct LocalDateFixture {}
-
-impl Default for LocalDateFixture {
-    fn default() -> Self {
-        LocalDateFixture {}
-    }
-}
-
-impl DateFixture<Local> for LocalDateFixture {
-    fn timezone(&self) -> Local {
-        Local
-    }
-
-    fn now(&self) -> DateTime<Local> {
-        Local::now()
-    }
-
-    fn today(&self) -> Date<Local> {
-        Local::today()
-    }
-}
-
-pub struct FixedOffsetDateFixture {
-    offset: FixedOffset,
-}
-
-impl From<FixedOffset> for FixedOffsetDateFixture {
-    fn from(offset: FixedOffset) -> Self {
-        FixedOffsetDateFixture { offset }
-    }
-}
-
-impl DateFixture<FixedOffset> for FixedOffsetDateFixture {
-    fn timezone(&self) -> FixedOffset {
-        self.offset
-    }
-
-    fn now(&self) -> DateTime<FixedOffset> {
-        self.offset.from_utc_datetime(&Utc::now().naive_utc())
-    }
-
-    fn today(&self) -> Date<FixedOffset> {
-        self.now().date()
     }
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -1,0 +1,42 @@
+use chrono::{Date, DateTime, TimeZone};
+
+mod fixed;
+mod local;
+mod utc;
+
+use crate::timedelta::{ApplyDateTime, TimeDeltaBuilder};
+pub use fixed::FixedOffsetProvider;
+pub use local::LocalProvider;
+pub use utc::UtcProvider;
+
+pub trait DateTimeProvider<Tz: TimeZone> {
+    fn timezone(&self) -> Tz;
+
+    fn now(&self) -> DateTime<Tz>;
+
+    fn today(&self) -> Date<Tz> {
+        self.now().date()
+    }
+
+    fn tomorrow(&self) -> Date<Tz> {
+        add_days(self.today(), 1)
+    }
+
+    fn yesterday(&self) -> Date<Tz> {
+        add_days(self.today(), -1)
+    }
+}
+
+pub trait FromTimeZone<Tz: TimeZone> {
+    fn from_timezone(tz: Tz) -> Self
+    where
+        Self: DateTimeProvider<Tz>;
+}
+
+fn add_days<Tz: TimeZone>(date: Date<Tz>, days: i32) -> Date<Tz> {
+    let delta = TimeDeltaBuilder::default().days(days).build();
+    delta
+        .apply_datetime(date.and_hms(0, 0, 0))
+        .expect(&format!("can't add days. date={:?}, days={}", date, days))
+        .date()
+}

--- a/src/provider/fixed.rs
+++ b/src/provider/fixed.rs
@@ -1,0 +1,27 @@
+use chrono::offset::TimeZone;
+use chrono::{DateTime, FixedOffset, Utc};
+
+use crate::provider::{DateTimeProvider, FromTimeZone};
+
+pub struct FixedOffsetProvider {
+    offset: FixedOffset,
+}
+
+impl DateTimeProvider<FixedOffset> for FixedOffsetProvider {
+    fn timezone(&self) -> FixedOffset {
+        self.offset
+    }
+
+    fn now(&self) -> DateTime<FixedOffset> {
+        self.offset.from_utc_datetime(&Utc::now().naive_utc())
+    }
+}
+
+impl FromTimeZone<FixedOffset> for FixedOffsetProvider {
+    fn from_timezone(offset: FixedOffset) -> Self
+    where
+        Self: DateTimeProvider<FixedOffset>,
+    {
+        FixedOffsetProvider { offset }
+    }
+}

--- a/src/provider/local.rs
+++ b/src/provider/local.rs
@@ -1,0 +1,24 @@
+use chrono::{DateTime, Local};
+
+use crate::provider::{DateTimeProvider, FromTimeZone};
+
+pub struct LocalProvider {}
+
+impl DateTimeProvider<Local> for LocalProvider {
+    fn timezone(&self) -> Local {
+        Local
+    }
+
+    fn now(&self) -> DateTime<Local> {
+        Local::now()
+    }
+}
+
+impl FromTimeZone<Local> for LocalProvider {
+    fn from_timezone(_tz: Local) -> Self
+    where
+        Self: DateTimeProvider<Local>,
+    {
+        LocalProvider {}
+    }
+}

--- a/src/provider/utc.rs
+++ b/src/provider/utc.rs
@@ -1,0 +1,24 @@
+use chrono::{DateTime, Utc};
+
+use crate::provider::{DateTimeProvider, FromTimeZone};
+
+pub struct UtcProvider {}
+
+impl DateTimeProvider<Utc> for UtcProvider {
+    fn timezone(&self) -> Utc {
+        Utc
+    }
+
+    fn now(&self) -> DateTime<Utc> {
+        Utc::now()
+    }
+}
+
+impl FromTimeZone<Utc> for UtcProvider {
+    fn from_timezone(_tz: Utc) -> Self
+    where
+        Self: DateTimeProvider<Utc>,
+    {
+        UtcProvider {}
+    }
+}


### PR DESCRIPTION
- rename struct which includes a `DateTime` related method.
- separate provider modules into each timezone.