### PR TITLE
Fix clippy warnings.

### DIFF
--- a/src/argv/hms.rs
+++ b/src/argv/hms.rs
@@ -72,9 +72,9 @@ impl FromStr for Hms {
 
         re.captures(text)
             .map(|capture| {
-                let h = extract_number(capture.get(1).or(capture.get(4)));
-                let m = extract_number(capture.get(2).or(capture.get(5)));
-                let s = extract_number(capture.get(3).or(capture.get(6)));
+                let h = extract_number(capture.get(1).or_else(|| capture.get(4)));
+                let m = extract_number(capture.get(2).or_else(|| capture.get(5)));
+                let s = extract_number(capture.get(3).or_else(|| capture.get(6)));
 
                 validate_number(h, 0, 23, || HmsError::WrongHour(text.to_string()))
                     .and_then(|_| {
@@ -85,7 +85,7 @@ impl FromStr for Hms {
                     })
                     .map(|_| Hms { h, m, s })
             })
-            .unwrap_or(Err(HmsError::WrongFormat(text.to_string())))
+            .unwrap_or_else(|| Err(HmsError::WrongFormat(text.to_string())))
     }
 }
 

--- a/src/argv/offset.rs
+++ b/src/argv/offset.rs
@@ -78,8 +78,8 @@ impl FromStr for Offset {
                         _ => 1,
                     })
                     .unwrap_or(1);
-                let h = extract_number(capture.get(2).or(capture.get(4))).unwrap_or(0);
-                let m = extract_number(capture.get(3).or(capture.get(5))).unwrap_or(0);
+                let h = extract_number(capture.get(2).or_else(|| capture.get(4))).unwrap_or(0);
+                let m = extract_number(capture.get(3).or_else(|| capture.get(5))).unwrap_or(0);
 
                 validate_number(h, 0, 23, || OffsetError::WrongHour(text.to_string()))
                     .and_then(|_| {
@@ -87,7 +87,7 @@ impl FromStr for Offset {
                     })
                     .map(|_| Offset { sign, h, m })
             })
-            .unwrap_or(Err(OffsetError::WrongFormat(text.to_string())))
+            .unwrap_or_else(|| Err(OffsetError::WrongFormat(text.to_string())))
     }
 }
 

--- a/src/argv/ymd.rs
+++ b/src/argv/ymd.rs
@@ -89,9 +89,9 @@ impl FromStr for Ymd {
 
         re.captures(s)
             .map(|capture| {
-                let y = extract_number(capture.get(1).or(capture.get(4)));
-                let m = extract_number(capture.get(2).or(capture.get(5)));
-                let d = extract_number(capture.get(3).or(capture.get(6)));
+                let y = extract_number(capture.get(1).or_else(|| capture.get(4)));
+                let m = extract_number(capture.get(2).or_else(|| capture.get(5)));
+                let d = extract_number(capture.get(3).or_else(|| capture.get(6)));
 
                 validate_number(y, 1900, 2999, || {
                     YmdError::WrongYear(s.to_string(), 1900, 2999)
@@ -100,7 +100,7 @@ impl FromStr for Ymd {
                 .and_then(|_| validate_number(d, 1, 31, || YmdError::WrongDay(s.to_string())))
                 .map(|_| Ymd { y, m, d })
             })
-            .unwrap_or(Err(YmdError::WrongFormat(s.to_string())))
+            .unwrap_or_else(|| Err(YmdError::WrongFormat(s.to_string())))
     }
 }
 
@@ -183,5 +183,4 @@ mod tests {
         assert!(YmdArgv::<Utc>::validate_argv("2019-06-123".to_string()).is_err());
         assert!(YmdArgv::<Utc>::validate_argv("--".to_string()).is_err());
     }
-
 }

--- a/src/cmd/generate.rs
+++ b/src/cmd/generate.rs
@@ -132,11 +132,13 @@ where
 
     let maybe_date = maybe_preset.map(|p| p.as_date(&provider)).or(maybe_ymd);
     let has_date = maybe_date.is_some();
-    let date = maybe_date.unwrap_or(now.date());
-    let time = maybe_hms.unwrap_or(if has_date {
-        NaiveTime::from_hms(0, 0, 0)
-    } else {
-        now.time()
+    let date = maybe_date.unwrap_or_else(|| now.date());
+    let time = maybe_hms.unwrap_or_else(|| {
+        if has_date {
+            NaiveTime::from_hms(0, 0, 0)
+        } else {
+            now.time()
+        }
     });
 
     Ok(maybe_truncate
@@ -148,7 +150,7 @@ fn create_deltas(maybe_values: Option<Values>) -> Result<Vec<DeltaItem>, UtError
     let delta_argv = DeltaArgv::default();
     maybe_values
         .map(|values| values.map(|s| delta_argv.parse_argv(s)).collect())
-        .unwrap_or(Ok(Vec::new()))
+        .unwrap_or_else(|| Ok(Vec::new()))
 }
 
 fn generate<Tz: TimeZone>(request: Request<Tz>) -> Result<(), UtError> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 use std::env;
 
-static OFFSET_KEY: &'static str = "UT_OFFSET";
-static PRECISION_KEY: &'static str = "UT_PRECISION";
+static OFFSET_KEY: &str = "UT_OFFSET";
+static PRECISION_KEY: &str = "UT_PRECISION";
 
 #[derive(Debug)]
 pub struct Config {

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -31,7 +31,7 @@ impl DeltaItem {
         DeltaItem { unit, value }
     }
 
-    pub fn apply_timedelta_builder(&self, builder: TimeDeltaBuilder) -> TimeDeltaBuilder {
+    pub fn apply_timedelta_builder(self, builder: TimeDeltaBuilder) -> TimeDeltaBuilder {
         match self.unit {
             TimeUnit::Year => builder.add_years(self.value),
             TimeUnit::Month => builder.add_months(self.value),
@@ -64,7 +64,7 @@ impl FromStr for DeltaItem {
                     .map_err(DeltaItemError::TimeUnitFindError)
                     .and_then(|unit| r_value.map(|value| DeltaItem { unit, value }))
             })
-            .unwrap_or(Err(DeltaItemError::WrongFormat(s.to_string())))
+            .unwrap_or_else(|| Err(DeltaItemError::WrongFormat(s.to_string())))
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,6 +41,7 @@ impl Fail for UtError {
         self.inner.name()
     }
 
+    #[allow(bare_trait_objects)] // Fail trait requires this signature.
     fn cause(&self) -> Option<&Fail> {
         self.inner.cause()
     }

--- a/src/find.rs
+++ b/src/find.rs
@@ -26,7 +26,7 @@ where
     E: IntoEnumIterator<Iterator = I> + FromStr + Copy + Display,
     I: Iterator<Item = E>,
 {
-    E::from_str(name).map(|x| Ok(x)).unwrap_or_else(|_| {
+    E::from_str(name).map(Ok).unwrap_or_else(|_| {
         let items = find_items(E::iter(), name);
         if items.len() == 1 {
             Ok(*items.first().unwrap())

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,14 +75,14 @@ fn run() -> Result<(), UtError> {
     let precision = PrecisionArgv::default().parse_argv(
         main_matches
             .value_of("PRECISION")
-            .or(config.precision())
+            .or_else(|| config.precision())
             .unwrap_or("second"),
     )?;
 
     if main_matches.is_present("UTC") {
         let provider: UtcProvider = UtcProvider::from_timezone(Utc);
         run_with(&main_matches, provider, precision)
-    } else if let Some(offset_text) = main_matches.value_of("OFFSET").or(config.offset()) {
+    } else if let Some(offset_text) = main_matches.value_of("OFFSET").or_else(|| config.offset()) {
         let offset = OffsetArgv::default().parse_argv(offset_text)?;
         let provider: FixedOffsetProvider = FixedOffsetProvider::from_timezone(offset);
         run_with(&main_matches, provider, precision)

--- a/src/precision.rs
+++ b/src/precision.rs
@@ -29,22 +29,22 @@ impl Precision {
         Precision::iter().map(|p| p.to_string()).collect()
     }
 
-    pub fn parse_timestamp<Tz: TimeZone>(&self, tz: Tz, timestamp: i64) -> DateTime<Tz> {
-        match *self {
+    pub fn parse_timestamp<Tz: TimeZone>(self, tz: Tz, timestamp: i64) -> DateTime<Tz> {
+        match self {
             Precision::Second => tz.timestamp(timestamp, 0),
             Precision::MilliSecond => tz.timestamp_millis(timestamp),
         }
     }
 
-    pub fn to_timestamp<Tz: TimeZone>(&self, dt: DateTime<Tz>) -> i64 {
-        match *self {
+    pub fn to_timestamp<Tz: TimeZone>(self, dt: DateTime<Tz>) -> i64 {
+        match self {
             Precision::Second => dt.timestamp(),
             Precision::MilliSecond => dt.timestamp_millis(),
         }
     }
 
-    pub fn preferred_format(&self) -> &'static str {
-        match *self {
+    pub fn preferred_format(self) -> &'static str {
+        match self {
             Precision::Second => "%Y-%m-%d %H:%M:%S (%Z)",
             Precision::MilliSecond => "%Y-%m-%d %H:%M:%S%.3f (%Z)",
         }

--- a/src/preset.rs
+++ b/src/preset.rs
@@ -33,12 +33,12 @@ impl Preset {
         Preset::iter().map(|p| p.to_string()).collect()
     }
 
-    pub fn as_date<P, Tz>(&self, provider: &P) -> Date<Tz>
+    pub fn as_date<P, Tz>(self, provider: &P) -> Date<Tz>
     where
         P: DateTimeProvider<Tz>,
         Tz: TimeZone,
     {
-        match *self {
+        match self {
             Preset::Today => provider.today(),
             Preset::Tomorrow => provider.tomorrow(),
             Preset::Yesterday => provider.yesterday(),

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -37,6 +37,6 @@ fn add_days<Tz: TimeZone>(date: Date<Tz>, days: i32) -> Date<Tz> {
     let delta = TimeDeltaBuilder::default().days(days).build();
     delta
         .apply_datetime(date.and_hms(0, 0, 0))
-        .expect(&format!("can't add days. date={:?}, days={}", date, days))
+        .unwrap_or_else(|| panic!("can't add days. date={:?}, days={}", date, days))
         .date()
 }

--- a/src/timedelta.rs
+++ b/src/timedelta.rs
@@ -97,11 +97,11 @@ impl TimeDelta {
 
 impl<Tz: TimeZone> ApplyDateTime<Tz> for TimeDelta {
     fn apply_datetime(&self, target: DateTime<Tz>) -> Option<DateTime<Tz>> {
-        let duration = Duration::microseconds(self.microseconds() as i64)
-            + Duration::seconds(self.seconds() as i64)
-            + Duration::minutes(self.minutes() as i64)
-            + Duration::hours(self.hours() as i64)
-            + Duration::days(self.days() as i64);
+        let duration = Duration::microseconds(i64::from(self.microseconds()))
+            + Duration::seconds(i64::from(self.seconds()))
+            + Duration::minutes(i64::from(self.minutes()))
+            + Duration::hours(i64::from(self.hours()))
+            + Duration::days(i64::from(self.days()));
 
         let duration_applied: DateTime<Tz> = target + duration;
 

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -44,14 +44,14 @@ impl TimeUnit {
         TimeUnit::iter().map(|t| t.to_string()).collect()
     }
 
-    pub fn truncate<Tz: TimeZone>(&self, dt: DateTime<Tz>) -> DateTime<Tz> {
-        let d = match *self {
+    pub fn truncate<Tz: TimeZone>(self, dt: DateTime<Tz>) -> DateTime<Tz> {
+        let d = match self {
             TimeUnit::Year => dt.date().with_month(1).unwrap().with_day(1).unwrap(),
             TimeUnit::Month => dt.date().with_day(1).unwrap(),
             _ => dt.date(),
         };
 
-        match *self {
+        match self {
             TimeUnit::Hour => d.and_hms(dt.hour(), 0, 0),
             TimeUnit::Minute => d.and_hms(dt.hour(), dt.minute(), 0),
             TimeUnit::Second => d.and_hms(dt.hour(), dt.minute(), dt.second()),


### PR DESCRIPTION
- use `or_else` instead of `or` to get optional value.
- use `unwrap_or_else` instead of `unwrap_or` to recover from error.
- use `T::from` instead of `as T`
- remove redundant lifetime parameter (like `'static`)
- move ownership when instances should be dropped.