### PR TITLE
Refactor/remove redundant codes

### DIFF
--- a/src/cmd/generate/app.rs
+++ b/src/cmd/generate/app.rs
@@ -2,10 +2,10 @@ use clap::{App, Arg, SubCommand};
 
 use crate::datetime::{Hms, HmsError, Ymd, YmdError};
 use crate::delta::{DeltaItem, DeltaItemError};
-use crate::precision::Precision;
-use crate::preset::Preset;
-use crate::unit::TimeUnit;
-use crate::validate::{validate_argv, IntoValidationError};
+use crate::precision::{Precision, PrecisionError};
+use crate::preset::{Preset, PresetError};
+use crate::unit::{TimeUnit, TimeUnitError};
+use crate::validate::{validate_argv, validate_argv_by_name};
 
 pub fn command(name: &str) -> App<'static, 'static> {
     SubCommand::with_name(name)
@@ -18,11 +18,7 @@ pub fn command(name: &str) -> App<'static, 'static> {
                 .short("b")
                 .long("base")
                 .takes_value(true)
-                .validator(|s| {
-                    Preset::find_by_name(&s)
-                        .map(|_| ())
-                        .map_err(|e| e.into_validation_error())
-                })
+                .validator(validate_argv_by_name::<Preset, PresetError>)
                 .conflicts_with("YMD"),
         )
         .arg(
@@ -31,7 +27,7 @@ pub fn command(name: &str) -> App<'static, 'static> {
                 .help("Set the DATE in yyyyMMdd format.")
                 .long("ymd")
                 .takes_value(true)
-                .validator(|s| validate_argv::<Ymd, YmdError>(&s))
+                .validator(validate_argv::<Ymd, YmdError>)
                 .conflicts_with("BASE"),
         )
         .arg(
@@ -40,7 +36,7 @@ pub fn command(name: &str) -> App<'static, 'static> {
                 .help("Set the TIME in HHmmss format.")
                 .long("hms")
                 .takes_value(true)
-                .validator(|s| validate_argv::<Hms, HmsError>(&s)),
+                .validator(validate_argv::<Hms, HmsError>),
         )
         .arg(
             Arg::with_name("TRUNCATE")
@@ -50,11 +46,7 @@ pub fn command(name: &str) -> App<'static, 'static> {
                 .short("t")
                 .long("truncate")
                 .takes_value(true)
-                .validator(|s| {
-                    TimeUnit::find_by_name(&s)
-                        .map(|_| ())
-                        .map_err(|e| e.into_validation_error())
-                }),
+                .validator(validate_argv_by_name::<TimeUnit, TimeUnitError>),
         )
         .arg(
             Arg::with_name("DELTA")
@@ -73,7 +65,7 @@ Example:
                 .allow_hyphen_values(true)
                 .multiple(true)
                 .number_of_values(1)
-                .validator(|s| validate_argv::<DeltaItem, DeltaItemError>(&s)),
+                .validator(validate_argv::<DeltaItem, DeltaItemError>),
         )
         .arg(
             Arg::with_name("PRECISION")
@@ -82,10 +74,6 @@ Example:
                 .short("p")
                 .long("precision")
                 .takes_value(true)
-                .validator(|s| {
-                    Precision::find_by_name(&s)
-                        .map(|_| ())
-                        .map_err(|e| e.into_validation_error())
-                }),
+                .validator(validate_argv_by_name::<Precision, PrecisionError>),
         )
 }

--- a/src/cmd/parse/app.rs
+++ b/src/cmd/parse/app.rs
@@ -1,3 +1,4 @@
+use crate::find::FindByName;
 use crate::precision::Precision;
 use crate::validate::IntoValidationError;
 use clap::{App, AppSettings, Arg, SubCommand};

--- a/src/cmd/parse/run.rs
+++ b/src/cmd/parse/run.rs
@@ -2,11 +2,12 @@ use std::fmt::{Debug, Display};
 
 use chrono::{Offset, TimeZone};
 use clap::ArgMatches;
+use failure::ResultExt;
 
 use crate::error::{UtError, UtErrorKind};
+use crate::find::FindByName;
 use crate::precision::Precision;
 use crate::provider::DateTimeProvider;
-use failure::ResultExt;
 
 pub fn run<O, Tz, P>(m: &ArgMatches, provider: P, precision: Precision) -> Result<(), UtError>
 where
@@ -22,10 +23,7 @@ where
         .context(UtErrorKind::WrongTimestamp)?
         .unwrap();
 
-    let maybe_precision = m
-        .value_of("PRECISION")
-        .map(|s| Precision::find_by_name(s).map(Some))
-        .unwrap_or_else(|| Ok(None))
+    let maybe_precision = Precision::find_by_name_opt(m.value_of("PRECISION"))
         .context(UtErrorKind::PrecisionError)?;
     if maybe_precision.is_some() {
         eprintln!("-p PRECISION option is deprecated.");

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 use failure::Fail;
 use regex::Regex;
 
+use crate::find::FindByName;
 use crate::timedelta::TimeDeltaBuilder;
 use crate::unit::{TimeUnit, TimeUnitError};
 use crate::validate::IntoValidationError;

--- a/src/find.rs
+++ b/src/find.rs
@@ -9,7 +9,7 @@ pub enum FindError {
     Ambiguous(Vec<String>),
 }
 
-pub fn find_items<E, I>(items: I, name: &str) -> Vec<E>
+fn find_items<E, I>(items: I, name: &str) -> Vec<E>
 where
     E: ToString + Copy,
     I: Iterator<Item = E>,
@@ -33,13 +33,19 @@ where
     }
 }
 
-pub trait PossibleValues: ToString + Copy {
+pub trait PossibleValues: Copy {
     type Iterator: Iterator<Item = Self>;
 
     fn possible_values() -> Self::Iterator;
 }
 
-pub trait FindByName: PossibleValues {
+pub trait PossibleNames: PossibleValues + ToString {
+    fn possible_names() -> Vec<String> {
+        Self::possible_values().map(|x| x.to_string()).collect()
+    }
+}
+
+pub trait FindByName: PossibleValues + ToString {
     type Error: From<FindError>;
 
     fn find_by_name(name: &str) -> Result<Self, Self::Error> {

--- a/src/find.rs
+++ b/src/find.rs
@@ -65,11 +65,3 @@ pub trait FindByName: PossibleValues + ToString + FromStr {
             .unwrap_or_else(|| Ok(None))
     }
 }
-
-pub fn enum_names<E, I>(items: I) -> Vec<String>
-where
-    E: ToString,
-    I: Iterator<Item = E>,
-{
-    items.map(|x| x.to_string()).collect()
-}

--- a/src/find.rs
+++ b/src/find.rs
@@ -1,8 +1,4 @@
-use std::fmt::Display;
-use std::str::FromStr;
-
 use failure::Fail;
-use strum::IntoEnumIterator;
 
 #[derive(Fail, Debug, PartialEq)]
 pub enum FindError {
@@ -21,22 +17,40 @@ where
     items.filter(|x| x.to_string().starts_with(name)).collect()
 }
 
-pub fn find_enum_item<E, I>(name: &str) -> Result<E, FindError>
+fn find_by_name<T, I>(items: I, name: &str) -> Result<T, FindError>
 where
-    E: IntoEnumIterator<Iterator = I> + FromStr + Copy + Display,
-    I: Iterator<Item = E>,
+    T: Copy + ToString,
+    I: Iterator<Item = T>,
 {
-    E::from_str(name).map(Ok).unwrap_or_else(|_| {
-        let items = find_items(E::iter(), name);
-        if items.len() == 1 {
-            Ok(*items.first().unwrap())
-        } else if items.is_empty() {
-            Err(FindError::NotFound)
-        } else {
-            let names = items.into_iter().map(|x| x.to_string()).collect();
-            Err(FindError::Ambiguous(names))
-        }
-    })
+    let found = find_items(items, name);
+    if found.len() == 1 {
+        Ok(*found.first().unwrap())
+    } else if found.is_empty() {
+        Err(FindError::NotFound)
+    } else {
+        let names = found.into_iter().map(|x| x.to_string()).collect();
+        Err(FindError::Ambiguous(names))
+    }
+}
+
+pub trait PossibleValues: ToString + Copy {
+    type Iterator: Iterator<Item = Self>;
+
+    fn possible_values() -> Self::Iterator;
+}
+
+pub trait FindByName: PossibleValues {
+    type Error: From<FindError>;
+
+    fn find_by_name(name: &str) -> Result<Self, Self::Error> {
+        Ok(find_by_name(Self::possible_values(), name)?)
+    }
+
+    fn find_by_name_opt(maybe_name: Option<&str>) -> Result<Option<Self>, Self::Error> {
+        maybe_name
+            .map(move |s| Self::find_by_name(s).map(Some))
+            .unwrap_or_else(|| Ok(None))
+    }
 }
 
 pub fn enum_names<E, I>(items: I) -> Vec<String>

--- a/src/find.rs
+++ b/src/find.rs
@@ -1,5 +1,6 @@
-use failure::Fail;
 use std::str::FromStr;
+
+use failure::Fail;
 
 #[derive(Fail, Debug, PartialEq)]
 pub enum FindError {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,11 +14,13 @@ mod unit;
 mod validate;
 
 use std::fmt::{Debug, Display};
+use std::str::FromStr;
 
 use chrono::{Local, TimeZone, Utc};
 use clap::{
     crate_authors, crate_description, crate_name, crate_version, App, AppSettings, Arg, ArgMatches,
 };
+use failure::ResultExt;
 
 use crate::config::Config;
 use crate::error::{UtError, UtErrorKind};
@@ -29,8 +31,6 @@ use crate::provider::{
     DateTimeProvider, FixedOffsetProvider, FromTimeZone, LocalProvider, UtcProvider,
 };
 use crate::validate::{validate_argv, validate_argv_by_name};
-use failure::ResultExt;
-use std::str::FromStr;
 
 fn app() -> App<'static, 'static> {
     App::new(crate_name!())

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -186,7 +186,7 @@ mod tests {
 
     #[test]
     fn validate() {
-        let validate_argv = |s: &str| validate_argv::<Offset, OffsetError>(s);
+        let validate_argv = |s: &str| validate_argv::<Offset, OffsetError>(s.to_string());
 
         assert!(validate_argv("0000").is_ok());
         assert!(validate_argv("00:00").is_ok());

--- a/src/precision.rs
+++ b/src/precision.rs
@@ -1,17 +1,10 @@
 use chrono::{DateTime, TimeZone};
 use failure::Fail;
-use lazy_static::lazy_static;
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter, EnumString};
 
-use crate::find::{enum_names, FindByName, FindError, PossibleValues};
+use crate::find::{FindByName, FindError, PossibleNames, PossibleValues};
 use crate::validate::IntoValidationError;
-
-lazy_static! {
-    static ref PRESET_NAMES: Vec<String> = enum_names(Precision::iter());
-    static ref POSSIBLE_VALUES: Vec<&'static str> =
-        PRESET_NAMES.iter().map(|s| s.as_str()).collect();
-}
 
 #[derive(Fail, Debug, PartialEq)]
 pub enum PrecisionError {
@@ -50,10 +43,6 @@ pub enum Precision {
 }
 
 impl Precision {
-    pub fn possible_names() -> Vec<String> {
-        Precision::iter().map(|p| p.to_string()).collect()
-    }
-
     pub fn parse_timestamp<Tz: TimeZone>(self, tz: Tz, timestamp: i64) -> DateTime<Tz> {
         match self {
             Precision::Second => tz.timestamp(timestamp, 0),
@@ -75,6 +64,8 @@ impl Precision {
         }
     }
 }
+
+impl PossibleNames for Precision {}
 
 impl PossibleValues for Precision {
     type Iterator = PrecisionIter;

--- a/src/precision.rs
+++ b/src/precision.rs
@@ -4,7 +4,7 @@ use lazy_static::lazy_static;
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter, EnumString};
 
-use crate::find::{enum_names, find_enum_item, FindError};
+use crate::find::{enum_names, FindByName, FindError, PossibleValues};
 use crate::validate::IntoValidationError;
 
 lazy_static! {
@@ -17,6 +17,12 @@ lazy_static! {
 pub enum PrecisionError {
     #[fail(display = "Wrong precision. error:{}", _0)]
     WrongName(FindError),
+}
+
+impl From<FindError> for PrecisionError {
+    fn from(e: FindError) -> Self {
+        PrecisionError::WrongName(e)
+    }
 }
 
 impl IntoValidationError for PrecisionError {
@@ -44,10 +50,6 @@ pub enum Precision {
 }
 
 impl Precision {
-    pub fn find_by_name(name: &str) -> Result<Precision, PrecisionError> {
-        find_enum_item(&name.to_ascii_lowercase()).map_err(PrecisionError::WrongName)
-    }
-
     pub fn possible_names() -> Vec<String> {
         Precision::iter().map(|p| p.to_string()).collect()
     }
@@ -74,12 +76,24 @@ impl Precision {
     }
 }
 
+impl PossibleValues for Precision {
+    type Iterator = PrecisionIter;
+
+    fn possible_values() -> Self::Iterator {
+        Precision::iter()
+    }
+}
+
+impl FindByName for Precision {
+    type Error = PrecisionError;
+}
+
 #[cfg(test)]
 mod tests {
     use chrono::offset::TimeZone;
     use chrono::Utc;
 
-    use crate::find::FindError;
+    use crate::find::{FindByName, FindError};
     use crate::precision::{Precision, PrecisionError};
 
     #[test]

--- a/src/preset.rs
+++ b/src/preset.rs
@@ -6,7 +6,7 @@ use lazy_static::lazy_static;
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter, EnumString};
 
-use crate::find::{enum_names, FindByName, FindError, PossibleValues};
+use crate::find::{enum_names, FindByName, FindError, PossibleNames, PossibleValues};
 use crate::provider::DateTimeProvider;
 use crate::validate::IntoValidationError;
 
@@ -56,10 +56,6 @@ lazy_static! {
 }
 
 impl Preset {
-    pub fn possible_names() -> Vec<String> {
-        Preset::iter().map(|p| p.to_string()).collect()
-    }
-
     pub fn as_date<P, Tz>(self, provider: &P) -> Date<Tz>
     where
         P: DateTimeProvider<Tz>,
@@ -80,6 +76,8 @@ impl PossibleValues for Preset {
         Preset::iter()
     }
 }
+
+impl PossibleNames for Preset {}
 
 impl FindByName for Preset {
     type Error = PresetError;

--- a/src/preset.rs
+++ b/src/preset.rs
@@ -2,11 +2,10 @@ use std::fmt::Debug;
 
 use chrono::{Date, TimeZone};
 use failure::Fail;
-use lazy_static::lazy_static;
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter, EnumString};
 
-use crate::find::{enum_names, FindByName, FindError, PossibleNames, PossibleValues};
+use crate::find::{FindByName, FindError, PossibleNames, PossibleValues};
 use crate::provider::DateTimeProvider;
 use crate::validate::IntoValidationError;
 
@@ -47,12 +46,6 @@ pub enum Preset {
 
     #[strum(serialize = "yesterday")]
     Yesterday,
-}
-
-lazy_static! {
-    static ref PRESET_NAMES: Vec<String> = enum_names(Preset::iter());
-    static ref POSSIBLE_VALUES: Vec<&'static str> =
-        PRESET_NAMES.iter().map(|s| s.as_str()).collect();
 }
 
 impl Preset {

--- a/src/preset.rs
+++ b/src/preset.rs
@@ -6,7 +6,7 @@ use lazy_static::lazy_static;
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter, EnumString};
 
-use crate::find::{enum_names, find_enum_item, FindError};
+use crate::find::{enum_names, FindByName, FindError, PossibleValues};
 use crate::provider::DateTimeProvider;
 use crate::validate::IntoValidationError;
 
@@ -14,6 +14,12 @@ use crate::validate::IntoValidationError;
 pub enum PresetError {
     #[fail(display = "Wrong preset. error:{}", _0)]
     WrongName(FindError),
+}
+
+impl From<FindError> for PresetError {
+    fn from(e: FindError) -> Self {
+        PresetError::WrongName(e)
+    }
 }
 
 impl IntoValidationError for PresetError {
@@ -50,10 +56,6 @@ lazy_static! {
 }
 
 impl Preset {
-    pub fn find_by_name(name: &str) -> Result<Preset, PresetError> {
-        find_enum_item(&name.to_ascii_lowercase()).map_err(PresetError::WrongName)
-    }
-
     pub fn possible_names() -> Vec<String> {
         Preset::iter().map(|p| p.to_string()).collect()
     }
@@ -69,4 +71,16 @@ impl Preset {
             Preset::Yesterday => provider.yesterday(),
         }
     }
+}
+
+impl PossibleValues for Preset {
+    type Iterator = PresetIter;
+
+    fn possible_values() -> Self::Iterator {
+        Preset::iter()
+    }
+}
+
+impl FindByName for Preset {
+    type Error = PresetError;
 }

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -4,7 +4,7 @@ use lazy_static::lazy_static;
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter, EnumString};
 
-use crate::find::{enum_names, find_enum_item, FindError};
+use crate::find::{enum_names, FindByName, FindError, PossibleValues};
 use crate::validate::IntoValidationError;
 
 lazy_static! {
@@ -17,6 +17,12 @@ lazy_static! {
 pub enum TimeUnitError {
     #[fail(display = "Wrong unit. error:{}", _0)]
     WrongName(FindError),
+}
+
+impl From<FindError> for TimeUnitError {
+    fn from(e: FindError) -> Self {
+        TimeUnitError::WrongName(e)
+    }
 }
 
 impl IntoValidationError for TimeUnitError {
@@ -59,10 +65,6 @@ pub enum TimeUnit {
 }
 
 impl TimeUnit {
-    pub fn find_by_name(name: &str) -> Result<TimeUnit, TimeUnitError> {
-        find_enum_item(&name.to_ascii_lowercase()).map_err(TimeUnitError::WrongName)
-    }
-
     pub fn possible_names() -> Vec<String> {
         TimeUnit::iter().map(|t| t.to_string()).collect()
     }
@@ -89,9 +91,21 @@ impl TimeUnit {
     }
 }
 
+impl PossibleValues for TimeUnit {
+    type Iterator = TimeUnitIter;
+
+    fn possible_values() -> Self::Iterator {
+        TimeUnit::iter()
+    }
+}
+
+impl FindByName for TimeUnit {
+    type Error = TimeUnitError;
+}
+
 #[cfg(test)]
 mod find_tests {
-    use crate::find::FindError;
+    use crate::find::{FindByName, FindError};
     use crate::unit::{TimeUnit, TimeUnitError};
 
     #[test]

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -1,17 +1,10 @@
 use chrono::{DateTime, Datelike, TimeZone, Timelike};
 use failure::Fail;
-use lazy_static::lazy_static;
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter, EnumString};
 
-use crate::find::{enum_names, FindByName, FindError, PossibleNames, PossibleValues};
+use crate::find::{FindByName, FindError, PossibleNames, PossibleValues};
 use crate::validate::IntoValidationError;
-
-lazy_static! {
-    static ref PRESET_NAMES: Vec<String> = enum_names(TimeUnit::iter());
-    static ref POSSIBLE_VALUES: Vec<&'static str> =
-        PRESET_NAMES.iter().map(|s| s.as_str()).collect();
-}
 
 #[derive(Fail, Debug, PartialEq)]
 pub enum TimeUnitError {

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -4,7 +4,7 @@ use lazy_static::lazy_static;
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter, EnumString};
 
-use crate::find::{enum_names, FindByName, FindError, PossibleValues};
+use crate::find::{enum_names, FindByName, FindError, PossibleNames, PossibleValues};
 use crate::validate::IntoValidationError;
 
 lazy_static! {
@@ -65,10 +65,6 @@ pub enum TimeUnit {
 }
 
 impl TimeUnit {
-    pub fn possible_names() -> Vec<String> {
-        TimeUnit::iter().map(|t| t.to_string()).collect()
-    }
-
     pub fn truncate<Tz: TimeZone>(self, dt: DateTime<Tz>) -> DateTime<Tz> {
         let d = match self {
             TimeUnit::Year => dt.date().with_month(1).unwrap().with_day(1).unwrap(),
@@ -98,6 +94,8 @@ impl PossibleValues for TimeUnit {
         TimeUnit::iter()
     }
 }
+
+impl PossibleNames for TimeUnit {}
 
 impl FindByName for TimeUnit {
     type Error = TimeUnitError;

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -1,5 +1,6 @@
-use crate::find::{FindByName, FindError};
 use std::str::FromStr;
+
+use crate::find::{FindByName, FindError};
 
 pub fn validate_number<T: PartialOrd, E, F: Fn() -> E>(
     n: T,

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -1,3 +1,4 @@
+use crate::find::{FindByName, FindError};
 use std::str::FromStr;
 
 pub fn validate_number<T: PartialOrd, E, F: Fn() -> E>(
@@ -17,12 +18,22 @@ pub trait IntoValidationError {
     fn into_validation_error(self) -> String;
 }
 
-pub fn validate_argv<T, E>(s: &str) -> Result<(), String>
+pub fn validate_argv<T, E>(s: String) -> Result<(), String>
 where
     T: FromStr<Err = E>,
     E: IntoValidationError,
 {
-    T::from_str(s)
+    T::from_str(s.as_ref())
+        .map(|_| ())
+        .map_err(|e| e.into_validation_error())
+}
+
+pub fn validate_argv_by_name<T, E>(s: String) -> Result<(), String>
+where
+    T: FindByName<Error = E>,
+    E: From<FindError> + IntoValidationError + IntoValidationError,
+{
+    T::find_by_name(s.as_ref())
         .map(|_| ())
         .map_err(|e| e.into_validation_error())
 }


### PR DESCRIPTION
- extract `find_by_name` as `FindByName` trait.
- extract `possible_names` as `PossibleNames` trait
- remove unused lazy_static variables.