### PR TITLE
Improve cache settings for Travis-CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: rust
-cache: cargo
+cache:
+  directories:
+    - $HOME/.cargo
+    - $HOME/.rustup
+before_cache:
+  - rm -rf /home/travis/.cargo/registry
 env:
   global:
     - PROJECT_NAME: ut-cli


### PR DESCRIPTION
Exclude $TRAVIS_BUILD_DIR/target from target to reduce caches.

See Also:
- https://docs.travis-ci.com/user/caching/#rust-cargo-cache
- https://qiita.com/justmonika/items/6cf62bbdb9b4913d9aa6