### PR TITLE
Add TIMESTAMP argument on generate command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ git clone https://github.com/yoshihitoh/ut-cli
 $ cd ut-cli
 $ cargo build --release
 $ ./target/release/ut --version
-ut 0.1.5
+ut 0.1.6
 ```
 
 Also there are pre-built binary for Linux and macOS.
@@ -52,7 +52,7 @@ See [releases](https://github.com/yoshihitoh/ut-cli/releases).
 
 ### Usage
 ``` bash
-ut-cli 0.1.5
+ut-cli 0.1.6
 yoshihitoh <yoshihito.arih@gmail.com>
 A command line tool to handle unix timestamp.
 
@@ -124,6 +124,10 @@ $ ut g -b today -d 3day -d 12hour -d 30minute
 # You can use short name on time unit.
 $ ut g -b today -d 3d -d 12h -d 30min
 1561174200
+
+# You can modify a timestamp with a timestamp argument.
+$ ut g -d 1min 1561174200
+1561174260    # 1min(=60second) difference.
 ```
 
 #### Parse a unix timestamp

--- a/src/cmd/generate/run.rs
+++ b/src/cmd/generate/run.rs
@@ -1,8 +1,9 @@
+use std::convert::TryFrom;
 use std::fmt::Debug;
 use std::str::FromStr;
 
 use chrono::prelude::*;
-use clap::{ArgMatches, Values};
+use clap::ArgMatches;
 use failure::ResultExt;
 
 use crate::datetime::{Hms, HmsError, Ymd, YmdError};
@@ -16,23 +17,121 @@ use crate::provider::DateTimeProvider;
 use crate::timedelta::{ApplyDateTime, TimeDeltaBuilder};
 use crate::unit::TimeUnit;
 
+#[derive(Debug)]
+struct GenerateOptions {
+    timestamp: Option<i64>,
+    preset: Option<Preset>,
+    ymd: Option<Ymd>,
+    hms: Option<Hms>,
+    truncate: Option<TimeUnit>,
+    deltas: Vec<DeltaItem>,
+}
+
+impl GenerateOptions {
+    pub fn base_datetime<P, Tz>(
+        &self,
+        provider: P,
+        precision: Precision,
+    ) -> Result<DateTime<Tz>, UtError>
+    where
+        Tz: TimeZone + Debug,
+        P: DateTimeProvider<Tz>,
+    {
+        //
+        let base = if let Some(timestamp) = self.timestamp {
+            precision.parse_timestamp(provider.timezone(), timestamp)
+        } else {
+            let now = provider.now();
+            let maybe_date = self.base_date(&provider)?;
+            let has_date = maybe_date.is_some();
+            let date = maybe_date.unwrap_or_else(|| now.date());
+            let time = self.hms.map(|hms| hms.into()).unwrap_or_else(|| {
+                if has_date {
+                    NaiveTime::from_hms(0, 0, 0)
+                } else {
+                    now.time()
+                }
+            });
+
+            date.and_time(time).unwrap()
+        };
+
+        Ok(self
+            .truncate
+            .iter()
+            .fold(base, |dt, unit| unit.truncate(dt)))
+    }
+
+    fn base_date<P, Tz>(&self, provider: &P) -> Result<Option<Date<Tz>>, UtError>
+    where
+        Tz: TimeZone + Debug,
+        P: DateTimeProvider<Tz>,
+    {
+        let date = self
+            .preset
+            .map(|p| Ok(Some(p.as_date(provider))))
+            .unwrap_or_else(|| {
+                self.ymd.map_or(Ok(None), |ymd| {
+                    ymd.into_date(&provider.timezone()).map(Some)
+                })
+            })
+            .context(UtErrorKind::WrongDate)?;
+
+        Ok(date)
+    }
+}
+
+impl TryFrom<&ArgMatches<'_>> for GenerateOptions {
+    type Error = UtError;
+
+    fn try_from(m: &ArgMatches<'_>) -> Result<Self, Self::Error> {
+        fn delta_item_from(s: &str) -> Result<DeltaItem, UtError> {
+            Ok(DeltaItem::from_str(s).context(UtErrorKind::DeltaError)?)
+        }
+
+        let timestamp = m
+            .value_of("BASE_TIMESTAMP")
+            .map(|s| {
+                i64::from_str(s)
+                    .map(Some)
+                    .context(UtErrorKind::WrongTimestamp)
+            })
+            .unwrap_or_else(|| Ok(None))?;
+        let preset =
+            Preset::find_by_name_opt(m.value_of("BASE")).context(UtErrorKind::PresetError)?;
+        let ymd =
+            parse_argv_opt::<Ymd, YmdError>(m.value_of("YMD")).context(UtErrorKind::WrongDate)?;
+        let hms =
+            parse_argv_opt::<Hms, HmsError>(m.value_of("HMS")).context(UtErrorKind::WrongTime)?;
+        let truncate = TimeUnit::find_by_name_opt(m.value_of("TRUNCATE"))
+            .context(UtErrorKind::TimeUnitError)?;
+        let deltas = m
+            .values_of("DELTA")
+            .map(|values| values.map(delta_item_from).collect())
+            .unwrap_or_else(|| Ok(Vec::new()))?;
+
+        Ok(GenerateOptions {
+            timestamp,
+            preset,
+            ymd,
+            hms,
+            truncate,
+            deltas,
+        })
+    }
+}
+
+struct GenerateRequest<Tz: TimeZone> {
+    base: DateTime<Tz>,
+    deltas: Vec<DeltaItem>,
+    precision: Precision,
+}
+
 pub fn run<Tz, P>(m: &ArgMatches, provider: P, precision: Precision) -> Result<(), UtError>
 where
     Tz: TimeZone + Debug,
     P: DateTimeProvider<Tz>,
 {
-    let maybe_preset =
-        Preset::find_by_name_opt(m.value_of("BASE")).context(UtErrorKind::PresetError)?;
-    let maybe_ymd =
-        parse_argv_opt::<Ymd, YmdError>(m.value_of("YMD")).context(UtErrorKind::WrongDate)?;
-    let maybe_hms =
-        parse_argv_opt::<Hms, HmsError>(m.value_of("HMS")).context(UtErrorKind::WrongTime)?;
-    let maybe_truncate =
-        TimeUnit::find_by_name_opt(m.value_of("TRUNCATE")).context(UtErrorKind::TimeUnitError)?;
-
-    let base = create_base_date(provider, maybe_preset, maybe_ymd, maybe_hms, maybe_truncate)?;
-    let deltas = create_deltas(m.values_of("DELTA"))?;
-
     let maybe_precision = Precision::find_by_name_opt(m.value_of("PRECISION"))
         .context(UtErrorKind::PrecisionError)?;
     if maybe_precision.is_some() {
@@ -40,68 +139,17 @@ where
     }
     let precision = maybe_precision.unwrap_or(precision);
 
-    generate(Request {
+    let generate_options = GenerateOptions::try_from(m)?;
+    let base = generate_options.base_datetime(provider, precision)?;
+    let deltas = generate_options.deltas;
+    generate(GenerateRequest {
         base,
         deltas,
         precision,
     })
 }
 
-struct Request<Tz: TimeZone> {
-    base: DateTime<Tz>,
-    deltas: Vec<DeltaItem>,
-    precision: Precision,
-}
-
-fn create_base_date<P, Tz>(
-    provider: P,
-    maybe_preset: Option<Preset>,
-    maybe_ymd: Option<Ymd>,
-    maybe_hms: Option<Hms>,
-    maybe_truncate: Option<TimeUnit>,
-) -> Result<DateTime<Tz>, UtError>
-where
-    Tz: TimeZone + Debug,
-    P: DateTimeProvider<Tz>,
-{
-    let now = provider.now();
-
-    let maybe_date = maybe_preset
-        .map(|p| Ok(Some(p.as_date(&provider))))
-        .unwrap_or_else(|| {
-            maybe_ymd.map_or(Ok(None), |ymd| {
-                ymd.into_date(&provider.timezone()).map(Some)
-            })
-        })
-        .context(UtErrorKind::WrongDate)?;
-
-    let has_date = maybe_date.is_some();
-    let date = maybe_date.unwrap_or_else(|| now.date());
-    let time = maybe_hms.map(|hms| hms.into()).unwrap_or_else(|| {
-        if has_date {
-            NaiveTime::from_hms(0, 0, 0)
-        } else {
-            now.time()
-        }
-    });
-
-    Ok(maybe_truncate
-        .iter()
-        .fold(date.and_time(time).unwrap(), |dt, unit| unit.truncate(dt)))
-}
-
-fn create_deltas(maybe_values: Option<Values>) -> Result<Vec<DeltaItem>, UtError> {
-    let deltas = maybe_values
-        .map(|values| {
-            values
-                .map(|s| DeltaItem::from_str(s).context(UtErrorKind::DeltaError))
-                .collect()
-        })
-        .unwrap_or_else(|| Ok(Vec::new()))?;
-    Ok(deltas)
-}
-
-fn generate<Tz: TimeZone>(request: Request<Tz>) -> Result<(), UtError> {
+fn generate<Tz: TimeZone>(request: GenerateRequest<Tz>) -> Result<(), UtError> {
     let delta = request
         .deltas
         .into_iter()

--- a/src/cmd/parse/app.rs
+++ b/src/cmd/parse/app.rs
@@ -6,7 +6,7 @@ use clap::{App, AppSettings, Arg, SubCommand};
 pub fn command(name: &str) -> App<'static, 'static> {
     SubCommand::with_name(name)
         .about("Parse a unix timestamp and print it in human readable format.")
-        .settings(&[AppSettings::AllowLeadingHyphen])
+        .settings(&[AppSettings::AllowNegativeNumbers, AppSettings::ColoredHelp])
         .arg(
             Arg::with_name("TIMESTAMP")
                 .help("Set a timestamp to parse.")

--- a/src/cmd/parse/run.rs
+++ b/src/cmd/parse/run.rs
@@ -15,14 +15,7 @@ where
     Tz: TimeZone<Offset = O> + Debug,
     P: DateTimeProvider<Tz>,
 {
-    // TODO: create timestamp type.
-    let timestamp = m
-        .value_of("TIMESTAMP")
-        .map(|s| s.parse::<i64>().map(Some))
-        .unwrap_or_else(|| Ok(None))
-        .context(UtErrorKind::WrongTimestamp)?
-        .unwrap();
-
+    let timestamp = get_timestamp(m.value_of("TIMESTAMP"))?;
     let maybe_precision = Precision::find_by_name_opt(m.value_of("PRECISION"))
         .context(UtErrorKind::PrecisionError)?;
     if maybe_precision.is_some() {
@@ -33,4 +26,10 @@ where
     let dt = precision.parse_timestamp(provider.timezone(), timestamp);
     println!("{}", dt.format(precision.preferred_format()).to_string());
     Ok(())
+}
+
+fn get_timestamp(maybe_timestamp: Option<&str>) -> Result<i64, UtError> {
+    Ok(maybe_timestamp
+        .map(|s| s.parse::<i64>().context(UtErrorKind::WrongTimestamp))
+        .unwrap()?)
 }


### PR DESCRIPTION
I experienced some situations that I needed to modify timestamps. (1days ago, 1hours later, etc...)
This PR will add functionality above on ut-cli.

Example.
``` bash
# get original time
$ ut g
1577174400

# show
$ ut p 1577174400
2019-12-24 17:00:00 (+09:00)

# modify timestamp, before 3 hours.
$ ut g -d -3h 1577174400
1577163600

# show
2019-12-24 14:00:00 (+09:00)
```